### PR TITLE
feat: Add Python to the list of languages

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -46,6 +46,7 @@ languages = [
     "Nix",
     "OCaml",
     "PureScript",
+    "Python",
     "Racket",
     "Roc",
     "Ruby",


### PR DESCRIPTION
Python was missing from `language_servers.wakatime.languages`.

I noticed my daily summaries were very compared to VSCode low and turns out the LSP was just inactive :smile: