### PR TITLE
Fix broken paths on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,13 @@ struct WakatimeExtension {
     cached_wakatime_cli_binary_path: Option<String>,
 }
 
+fn sanitize_path(path: &str) -> String {
+    match zed::current_platform() {
+        (zed::Os::Windows, _) => path.trim_start_matches("/").to_string(),
+        _ => path.to_string(),
+    }
+}
+
 impl WakatimeExtension {
     fn target_triple(&self, binary: &str) -> Result<String, String> {
         let (platform, arch) = zed::current_platform();
@@ -188,7 +195,7 @@ impl zed::Extension for WakatimeExtension {
                 .unwrap()
                 .to_string();
 
-            waka_cli
+            sanitize_path(waka_cli.as_str())
         }];
 
         Ok(Command {

--- a/wakatime-ls/src/main.rs
+++ b/wakatime-ls/src/main.rs
@@ -249,15 +249,11 @@ async fn main() {
         )
         .get_matches();
 
-    let mut wakatime_cli = if let Some(s) = matches.get_one::<String>("wakatime-cli") {
-        s
+    let wakatime_cli = if let Some(s) = matches.get_one::<String>("wakatime-cli") {
+        s.to_string()
     } else {
-        "wakatime-cli"
+        "wakatime-cli".to_string()
     };
-
-    if cfg!(windows) {
-        wakatime_cli = wakatime_cli.trim_start_matches("/");
-    }
 
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
@@ -266,7 +262,7 @@ async fn main() {
         Arc::new(WakatimeLanguageServer {
             client,
             settings: ArcSwap::from_pointee(Settings::default()),
-            wakatime_path: wakatime_cli.to_string(),
+            wakatime_path: wakatime_cli,
             platform: ArcSwap::from_pointee(String::new()),
             current_file: Mutex::new(CurrentFile {
                 uri: String::new(),

--- a/wakatime-ls/src/main.rs
+++ b/wakatime-ls/src/main.rs
@@ -249,11 +249,15 @@ async fn main() {
         )
         .get_matches();
 
-    let wakatime_cli = if let Some(s) = matches.get_one::<String>("wakatime-cli") {
-        s.to_string()
+    let mut wakatime_cli = if let Some(s) = matches.get_one::<String>("wakatime-cli") {
+        s
     } else {
-        "wakatime-cli".to_string()
+        "wakatime-cli"
     };
+
+    if cfg!(windows) {
+        wakatime_cli = wakatime_cli.trim_start_matches("/");
+    }
 
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
@@ -262,7 +266,7 @@ async fn main() {
         Arc::new(WakatimeLanguageServer {
             client,
             settings: ArcSwap::from_pointee(Settings::default()),
-            wakatime_path: wakatime_cli,
+            wakatime_path: wakatime_cli.to_string(),
             platform: ArcSwap::from_pointee(String::new()),
             current_file: Mutex::new(CurrentFile {
                 uri: String::new(),


### PR DESCRIPTION
The extension never worked on Windows due to `wakatime_path` on Windows having a leading slash.