### PR TITLE
fix: Zed configuration key in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Zed setting.Open zed setting file, add your api key
 ```json
 "lsp": {
   "wakatime": {
-    "settings": {
+    "initialization_options": {
       "api-key": "You api key"
     }
   }


### PR DESCRIPTION
We are looking for settings in `initialization_options`, not in `options`. Perhaps a mention of `api-url` should be added?

https://github.com/wakatime/zed-wakatime/blob/0ba49f18fc76ddd869543de12cbeaca69c4581b6/wakatime-ls/src/main.rs#L144-L166