### PR TITLE
Documentation: Link to wakatime-cli documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ create a file named `.wakatime.cfg`, locate your HOME directory.
 [settings]
 api_key = Your api key
 ```
+Go through up [wakatime-cli](https://github.com/wakatime/wakatime-cli/blob/develop/USAGE.md)'s documentation for more options.
 
 ### zed setting file
 Zed setting.Open zed setting file, add your api key


### PR DESCRIPTION
Added a link to wakatime-cli documentation for the user to read on more configuration options. This would help in users not familiar with wakatime-cli beforehand to know about more configuration options; would be useful to know that these aren't unsupported outright.
