### PR TITLE
Add OpenTofu language support

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -145,6 +145,7 @@ languages = [
     "OMNeT++ MSG",
     "OMNeT++ NED",
     "OpenSCAD",
+    "OpenTofu",
     "Org",
     "Pact",
     "Path of Exile Filter",


### PR DESCRIPTION
Enables the extension to run [OpenTofu](https://opentofu.org) files. 

These files are identical to Terraform files and will be handled as such by wakatime-cli, however currently the extension will not run in files using the [OpenTofu language server extension](https://github.com/ashpool37/zed-extension-opentofu)