### PR TITLE
Fix project detection from worktree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,7 +1110,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wakatime-ls"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "zed-wakatime"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 members = ["wakatime-ls"]
 
 [workspace.package]
-version = "0.1.10"
+version = "0.1.11"
 
 [profile.dist]
 inherits = "release"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "wakatime"
 name = "wakatime"
 description = "Wakatime support."
-version = "0.1.10"
+version = "0.1.11"
 schema_version = 1
 authors = ["Alan Hamlett <alan@wakatime.com>", "bestgopher <84328409@qq.com>"]
 repository = "https://github.com/wakatime/zed-wakatime"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,13 @@ fn executable_name(binary: &str) -> String {
     }
 }
 
+fn project_name_from_path(path: &str) -> Option<String> {
+    Path::new(path)
+        .file_name()
+        .and_then(|file_name| file_name.to_str())
+        .map(ToString::to_string)
+}
+
 impl WakatimeExtension {
     fn target_triple(&self, binary: &str) -> Result<String, String> {
         let (platform, arch) = zed::current_platform();
@@ -213,7 +220,7 @@ impl zed::Extension for WakatimeExtension {
 
         let ls_binary_path = self.language_server_binary_path(language_server_id)?;
 
-        let args = vec!["--wakatime-cli".to_string(), {
+        let mut args = vec!["--wakatime-cli".to_string(), {
             use std::env;
             let current = env::current_dir().unwrap();
             let waka_cli = if is_absolute_path_wasm(&wakatime_cli_binary_path) {
@@ -227,6 +234,19 @@ impl zed::Extension for WakatimeExtension {
             };
             sanitize_path(waka_cli.as_str())
         }];
+
+        let project_folder = sanitize_path(worktree.root_path().as_str());
+        if !project_folder.is_empty() {
+            args.push("--project-folder".to_string());
+            args.push(project_folder.clone());
+
+            if let Some(project_name) = project_name_from_path(project_folder.as_str()) {
+                if !project_name.is_empty() {
+                    args.push("--alternate-project".to_string());
+                    args.push(project_name);
+                }
+            }
+        }
 
         Ok(Command {
             args,

--- a/wakatime-ls/src/main.rs
+++ b/wakatime-ls/src/main.rs
@@ -33,6 +33,8 @@ struct WakatimeLanguageServer {
     client: Client,
     settings: ArcSwap<Settings>,
     wakatime_path: String,
+    project_folder: String,
+    alternate_project: String,
     current_file: Mutex<CurrentFile>,
     platform: ArcSwap<String>,
 }
@@ -81,6 +83,18 @@ impl WakatimeLanguageServer {
             .arg(event.is_write.to_string())
             .arg("--entity")
             .arg(event.uri.as_str());
+
+        if !self.project_folder.is_empty() {
+            command
+                .arg("--project-folder")
+                .arg(self.project_folder.as_str());
+        }
+
+        if !self.alternate_project.is_empty() {
+            command
+                .arg("--alternate-project")
+                .arg(self.alternate_project.as_str());
+        }
 
         if !self.platform.load().is_empty() {
             command.arg("--plugin").arg(self.platform.load().as_str());
@@ -265,12 +279,34 @@ async fn main() {
                 .help("wakatime-cli path")
                 .required(true),
         )
+        .arg(
+            Arg::new("project-folder")
+                .long("project-folder")
+                .help("project folder path"),
+        )
+        .arg(
+            Arg::new("alternate-project")
+                .long("alternate-project")
+                .help("alternate project name"),
+        )
         .get_matches();
 
     let wakatime_cli = if let Some(s) = matches.get_one::<String>("wakatime-cli") {
         s.to_string()
     } else {
         "wakatime-cli".to_string()
+    };
+
+    let project_folder = if let Some(s) = matches.get_one::<String>("project-folder") {
+        s.to_string()
+    } else {
+        String::new()
+    };
+
+    let alternate_project = if let Some(s) = matches.get_one::<String>("alternate-project") {
+        s.to_string()
+    } else {
+        String::new()
     };
 
     let stdin = tokio::io::stdin();
@@ -281,6 +317,8 @@ async fn main() {
             client,
             settings: ArcSwap::from_pointee(Settings::default()),
             wakatime_path: wakatime_cli,
+            project_folder,
+            alternate_project,
             platform: ArcSwap::from_pointee(String::new()),
             current_file: Mutex::new(CurrentFile {
                 uri: String::new(),


### PR DESCRIPTION
# Fix Project Detection In Zed WakaTime Plugin

## Summary
This change fixes project detection in the Zed WakaTime plugin by passing workspace context to `wakatime-cli` for each heartbeat.

Without this, project detection can fall back to file-level values, which causes individual files to appear as projects on the WakaTime dashboard.

## Problem
In the current Zed flow, heartbeats send `--entity` (file path) but do not send explicit project/workspace context.

As a result, some setups end up with entries like file names (`package.json`, `README.md`, etc.) grouped as projects instead of repository/worktree names.

## Screenshot (Problem Repro)
<img width="3148" height="2776" alt="Screenshot 2026-02-17 at 15-53-56 Projects - WakaTime" src="https://github.com/user-attachments/assets/1b662067-1590-4185-9022-31bfe5eb35c0" />

## What Changed
- Extension now passes:
  - `--project-folder <worktree root path>`
  - `--alternate-project <worktree folder name>`
- `wakatime-ls` now accepts and forwards these args to `wakatime-cli` when sending heartbeats.

## Why This Approach
This is intentionally aligned with the same concept used in the JetBrains WakaTime plugin:
- https://github.com/wakatime/jetbrains-wakatime

- JetBrains gets the IDE project name (`project.getName()`).
- JetBrains sends that project name to `wakatime-cli` as `--alternate-project`.

This PR applies the same idea for Zed by deriving project context from Zed's active worktree:
- `project-folder` comes from the worktree root path.
- `alternate-project` comes from the worktree folder name.

So the conceptual model is copied from the JetBrains plugin, adapted to Zed's extension/LSP architecture.

## Expected Result
Projects on the WakaTime dashboard should be recognized as repos/top-level worktrees (for example, `my-repo`) instead of individual file names.

## Validation
- Built `wakatime-ls` with this change.
- Verified the updated binary now supports:
  - `--project-folder`
  - `--alternate-project`
